### PR TITLE
feat: Create `auth().redirectToSignIn`

### DIFF
--- a/apps/playground-with-package/src/middleware.ts
+++ b/apps/playground-with-package/src/middleware.ts
@@ -1,3 +1,61 @@
 import { clerkMiddleware } from "astro-clerk-auth/server";
+import { defineMiddleware, sequence } from "astro:middleware";
 
-export const onRequest = clerkMiddleware();
+// export const onRequest = clerkMiddleware();
+
+/**
+ * 1. Support options
+ */
+// export const onRequest = clerkMiddleware();
+
+/**
+ * 2. Support chaining
+ */
+// const greeting = defineMiddleware(async (context, next) => {
+//   console.log("greeting request");
+//   console.log(context.locals.auth());
+//   const response = await next();
+//   console.log("greeting response");
+//   return response;
+// });
+
+// export const onRequest = sequence(
+//   clerkMiddleware({
+//     // TODO: This does not work
+//     afterSignInUrl: "/wow",
+//   }),
+//   greeting,
+// );
+
+/**
+ * 3. Support handler
+ */
+export const onRequest = clerkMiddleware((auth, context, next) => {
+  const requestURL = new URL(context.request.url);
+  if (["/sign-in", "/", "/sign-up"].includes(requestURL.pathname)) {
+    return next();
+  }
+
+  if (!auth().userId) {
+    return auth().redirectToSignIn();
+  }
+
+  if (
+    !auth().orgId &&
+    requestURL.pathname !== "/discover" &&
+    requestURL.pathname === "/organization"
+  ) {
+    const searchParams = new URLSearchParams({
+      redirectUrl: requestURL.href,
+    });
+
+    const orgSelection = new URL(
+      `/discover?${searchParams.toString()}`,
+      context.request.url,
+    );
+
+    return context.redirect(orgSelection.href);
+  }
+
+  return next();
+});

--- a/packages/astro-clerk-auth/src/server/server-redirect-with-auth.ts
+++ b/packages/astro-clerk-auth/src/server/server-redirect-with-auth.ts
@@ -1,0 +1,32 @@
+// Middleware runs on the server side, before clerk-js is loaded, that's why we need Cookies.
+import type { AuthenticateRequestOptions, ClerkRequest } from '@clerk/backend/internal';
+import { constants } from '@clerk/backend/internal';
+import { DEV_BROWSER_JWT_KEY, isDevelopmentFromSecretKey, setDevBrowserJWTInURL } from '@clerk/shared';
+import { SECRET_KEY } from '../v0/constants';
+import { AstroMiddlewareContextParam } from './types';
+
+/**
+ * Grabs the dev browser JWT from cookies and appends it to the redirect URL when redirecting to cross-origin.
+ */
+export const serverRedirectWithAuth = (
+  context: AstroMiddlewareContextParam,
+  clerkRequest: ClerkRequest,
+  res: Response,
+  opts: AuthenticateRequestOptions,
+) => {
+  const location = res.headers.get('location');
+  const shouldAppendDevBrowser = res.headers.get(constants.Headers.ClerkRedirectTo) === 'true';
+
+  if (
+    shouldAppendDevBrowser &&
+    !!location &&
+    isDevelopmentFromSecretKey(opts.secretKey || SECRET_KEY) &&
+    clerkRequest.clerkUrl.isCrossOrigin(location)
+  ) {
+    const dbJwt = clerkRequest.cookies.get(DEV_BROWSER_JWT_KEY) || '';
+    const url = new URL(location);
+    const urlWithDevBrowser = setDevBrowserJWTInURL(url, dbJwt);
+    return context.redirect(urlWithDevBrowser.href, 307);
+  }
+  return res;
+};

--- a/packages/astro-clerk-auth/src/server/types.ts
+++ b/packages/astro-clerk-auth/src/server/types.ts
@@ -1,8 +1,8 @@
-import type { defineMiddleware } from 'astro/middleware';
+import { MiddlewareNextResponse, MiddlewareResponseHandler } from 'astro';
 
-export type AstroMiddleware = Parameters<typeof defineMiddleware>[0];
+export type AstroMiddleware = MiddlewareResponseHandler
 export type AstroMiddlewareContextParam = Parameters<AstroMiddleware>['0'];
-export type AstroMiddlewareNextParam = Parameters<AstroMiddleware>['1'];
+export type AstroMiddlewareNextParam = MiddlewareNextResponse;
 export type AstroMiddlewareReturn =
   // Promise<void> | void |
   Response | Promise<Response>;

--- a/packages/astro-clerk-auth/src/server/utils.ts
+++ b/packages/astro-clerk-auth/src/server/utils.ts
@@ -45,3 +45,15 @@ export const parseJwt = (req: Request) => {
 
   return data;
 };
+
+export const isRedirect = (res: Response) => {
+  return (
+    [300, 301, 302, 303, 304, 307, 308].includes(res.status) ||
+    res.headers.get(constants.Headers.ClerkRedirectTo) === 'true'
+  );
+};
+
+export const setHeader = (res: Response, name: string, val: string) => {
+  res.headers.set(name, val);
+  return res;
+};


### PR DESCRIPTION
+ Fixed types for `clerkMiddleware` handler
+ Append db jwt cookie for cross-origin requests