### PR TITLE
chore: Remove `redirect` as AuthReason

### DIFF
--- a/.changeset/sour-pugs-dream.md
+++ b/.changeset/sour-pugs-dream.md
@@ -1,0 +1,5 @@
+---
+"astro-clerk-auth": patch
+---
+
+Remove `redirect` as AuthReason.

--- a/packages/astro-clerk-auth/src/server/clerk-middleware.ts
+++ b/packages/astro-clerk-auth/src/server/clerk-middleware.ts
@@ -85,8 +85,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
     }
 
     if (isRedirect(handlerResult)) {
-      const res = setHeader(handlerResult, constants.Headers.AuthReason, 'redirect');
-      return serverRedirectWithAuth(context, clerkRequest, res, options);
+      return serverRedirectWithAuth(context, clerkRequest, handlerResult, options);
     }
 
     const response = await decorateRequest(context.locals, handlerResult, requestState);


### PR DESCRIPTION
Keep the middleware aligned with the `clerkMiddleware` exported from clerk-nextjs