### PR TITLE
chore: Re-export @clerk/backend from '/server'

### DIFF
--- a/.changeset/eight-walls-sort.md
+++ b/.changeset/eight-walls-sort.md
@@ -1,0 +1,5 @@
+---
+"astro-clerk-auth": patch
+---
+
+Re-export @clerk/backend from '/server'

--- a/apps/playground-with-package/src/pages/index.astro
+++ b/apps/playground-with-package/src/pages/index.astro
@@ -14,13 +14,6 @@ import SignOutButton from "../lib/astro-components/SignOutButton.astro";
 import { ClerkLayout } from "astro-clerk-auth/components/control";
 import { SignedIn, SignedOut } from "astro-clerk-auth/components/react";
 import { OrganizationSwitcher } from "astro-clerk-auth/components/interactive";
-// import { clerkSSR } from "astro-clerk-auth/server";
-/**
- * Replacement of `<ClerkLayout/>`
- * Experimental pattern
- */
-// This currently doesnt work because Astro middleware has not populated `Astro.local.auth`
-// clerkSSR(Astro)
 ---
 
 <ClerkLayout protectedPage={true}>

--- a/packages/astro-clerk-auth/env.d.ts
+++ b/packages/astro-clerk-auth/env.d.ts
@@ -5,6 +5,6 @@ declare namespace App {
     authMessage: string | null;
     authReason: string | null;
     auth: () => import('astro-clerk-auth/server').GetAuthReturn;
-    currentUser: () => Promise<import('@clerk/backend').User | null>;
+    currentUser: () => Promise<import('astro-clerk-auth/server').User | null>;
   }
 }

--- a/packages/astro-clerk-auth/src/server/clerk-ssr.ts
+++ b/packages/astro-clerk-auth/src/server/clerk-ssr.ts
@@ -1,7 +1,0 @@
-import { AstroGlobal } from 'astro';
-
-// Do not use
-export const clerkSSR = (astro: AstroGlobal) => {
-  // @ts-ignore TODO: fix this
-  // $ssrState.set(astro.locals.auth());
-};

--- a/packages/astro-clerk-auth/src/server/index.ts
+++ b/packages/astro-clerk-auth/src/server/index.ts
@@ -1,7 +1,47 @@
-import { authAsyncStorage } from '../server/async-local-storage';
+/**
+ * Re-export utilities
+ */
+export { verifyToken, createClerkClient } from '@clerk/backend';
+
+/**
+ * Re-export types
+ */
+export type {
+  OrganizationMembershipRole,
+  // Webhook event types
+  WebhookEvent,
+  WebhookEventType,
+  // Resources
+  AllowlistIdentifier,
+  Client,
+  OrganizationMembership,
+  EmailAddress,
+  ExternalAccount,
+  Invitation,
+  OauthAccessToken,
+  Organization,
+  OrganizationInvitation,
+  OrganizationMembershipPublicUserData,
+  PhoneNumber,
+  Session,
+  SignInToken,
+  SMSMessage,
+  Token,
+  User,
+} from '@clerk/backend';
+
 
 export { clerkMiddleware } from './clerk-middleware';
-export { clerkSSR } from './clerk-ssr';
 export { createRouteMatcher } from './route-matcher';
+
+
+/**
+ * This will be used to define types of Astro.Locals inside `env.d.ts`
+ */
 export type { GetAuthReturn } from './get-auth';
+
+/**
+ * Export async storage for astro component to use directly
+ */
+import { authAsyncStorage } from '../server/async-local-storage';
 export const __internal_authAsyncStorage = authAsyncStorage;


### PR DESCRIPTION
- Remove `clerkSSR` as it was not used