### PR TITLE
fix: Update `create-integration` to handle empty params

### DIFF
--- a/.changeset/shiny-bats-know.md
+++ b/.changeset/shiny-bats-know.md
@@ -1,0 +1,5 @@
+---
+"astro-clerk-auth": patch
+---
+
+Bug fix: build fails when the integration was called with no arguments.

--- a/packages/astro-clerk-auth/src/env.d.ts
+++ b/packages/astro-clerk-auth/src/env.d.ts
@@ -1,17 +1,20 @@
 /// <reference types="astro/client" />
 
 interface ImportMetaEnv {
-    readonly PUBLIC_ASTRO_APP_CLERK_FRONTEND_API?: string;
-    readonly PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY?: string;
-    readonly CLERK_API_KEY?: string;
-    readonly CLERK_API_URL?: string;
-    readonly CLERK_API_VERSION?: string;
-    readonly CLERK_JWT_KEY?: string;
-    readonly CLERK_SECRET_KEY?: string;
-    readonly DATABASE_URL?:string;
-    readonly FLAG_GUESTBOOK?:string;
+  readonly PUBLIC_ASTRO_APP_CLERK_FRONTEND_API?: string;
+  readonly PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY?: string;
+  readonly PUBLIC_ASTRO_APP_CLERK_JS_URL?: string;
+  readonly PUBLIC_ASTRO_APP_CLERK_JS_VARIANT?: string;
+  readonly PUBLIC_ASTRO_APP_CLERK_JS_VERSION?: string;
+  readonly CLERK_API_KEY?: string;
+  readonly CLERK_API_URL?: string;
+  readonly CLERK_API_VERSION?: string;
+  readonly CLERK_JWT_KEY?: string;
+  readonly CLERK_SECRET_KEY?: string;
+  readonly DATABASE_URL?: string;
+  readonly FLAG_GUESTBOOK?: string;
 }
 
 interface ImportMeta {
-    readonly env: ImportMetaEnv;
+  readonly env: ImportMetaEnv;
 }

--- a/packages/astro-clerk-auth/src/env.d.ts
+++ b/packages/astro-clerk-auth/src/env.d.ts
@@ -4,7 +4,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_ASTRO_APP_CLERK_FRONTEND_API?: string;
   readonly PUBLIC_ASTRO_APP_CLERK_PUBLISHABLE_KEY?: string;
   readonly PUBLIC_ASTRO_APP_CLERK_JS_URL?: string;
-  readonly PUBLIC_ASTRO_APP_CLERK_JS_VARIANT?: string;
+  readonly PUBLIC_ASTRO_APP_CLERK_JS_VARIANT?: 'headless' | '';
   readonly PUBLIC_ASTRO_APP_CLERK_JS_VERSION?: string;
   readonly CLERK_API_KEY?: string;
   readonly CLERK_API_URL?: string;

--- a/packages/astro-clerk-auth/src/integration/create-integration.ts
+++ b/packages/astro-clerk-auth/src/integration/create-integration.ts
@@ -34,6 +34,10 @@ function createIntegration<P extends { mode: 'hotload' | 'bundled' }>({ mode }: 
             logger.error('Missing adapter, please update your Astro config to use one.');
           }
 
+          if (typeof clerkJSVariant !== undefined && clerkJSVariant !== 'headless' && clerkJSVariant !== '') {
+            logger.error('Invalid value for clerkJSVariant. Acceptable values are `"headless"`, `""`, and `undefined`');
+          }
+
           const defaultHotLoadImportPath = 'astro-clerk-auth/internal/hotload';
 
           const buildImportPath =

--- a/packages/astro-clerk-auth/src/integration/create-integration.ts
+++ b/packages/astro-clerk-auth/src/integration/create-integration.ts
@@ -19,9 +19,9 @@ function createIntegration<P extends { mode: 'hotload' | 'bundled' }>({ mode }: 
     const { proxyUrl, isSatellite, domain, afterSignInUrl, afterSignUpUrl, signInUrl, signUpUrl } = params || {};
 
     // This are not provided when the "bundled" integration is used
-    const clerkJSUrl = (params as any).clerkJSUrl as string;
-    const clerkJSVariant = (params as any).clerkJSVariant as string;
-    const clerkJSVersion = (params as any).clerkJSVersion as string;
+    const clerkJSUrl = (params as any)?.clerkJSUrl as string | undefined;
+    const clerkJSVariant = (params as any)?.clerkJSVariant as string | undefined;
+    const clerkJSVersion = (params as any)?.clerkJSVersion as string | undefined;
 
     return {
       name: '@astro-clerk-auth/integration',


### PR DESCRIPTION
Fixes #119 