### PR TITLE
chore: Drop url constants from Astro components

### DIFF
--- a/.changeset/tough-planes-boil.md
+++ b/.changeset/tough-planes-boil.md
@@ -1,0 +1,5 @@
+---
+"astro-clerk-auth": patch
+---
+
+Drop url constants from Astro components.

--- a/packages/astro-clerk-auth/src/astro-components/interactive/SignIn.astro
+++ b/packages/astro-clerk-auth/src/astro-components/interactive/SignIn.astro
@@ -2,14 +2,12 @@
 import type { SignInProps } from "@clerk/types";
 type Props = SignInProps;
 
-import { signUpUrl } from "astro-clerk-auth/v0";
 import { customAlphabet, urlAlphabet } from "nanoid";
 
 const safeId = customAlphabet(urlAlphabet, 10)();
 
 const props = {
-  ...Astro.props,
-  signUpUrl: Astro.props.signUpUrl || signUpUrl
+  ...Astro.props
 }
 ---
 

--- a/packages/astro-clerk-auth/src/astro-components/interactive/SignUp.astro
+++ b/packages/astro-clerk-auth/src/astro-components/interactive/SignUp.astro
@@ -2,14 +2,12 @@
 import type { SignUpProps } from "@clerk/types";
 type Props = SignUpProps;
 
-import { signInUrl } from "astro-clerk-auth/v0";
 import { customAlphabet, urlAlphabet } from "nanoid";
 
 const safeId = customAlphabet(urlAlphabet, 10)();
 
 const props = {
-  ...Astro.props,
-  signInUrl: Astro.props.signInUrl || signInUrl
+  ...Astro.props
 }
 ---
 

--- a/packages/astro-clerk-auth/src/astro-components/react/SignIn.astro
+++ b/packages/astro-clerk-auth/src/astro-components/react/SignIn.astro
@@ -2,12 +2,10 @@
 import type { SignInProps } from "@clerk/types";
 type Props = SignInProps
 
-import { signUpUrl } from "astro-clerk-auth/v0";
 import { SignIn as SignInReact } from "astro-clerk-auth/client/react";
 
 const props = {
-  ...Astro.props,
-  signUpUrl: Astro.props.signUpUrl || signUpUrl
+  ...Astro.props
 }
 ---
 

--- a/packages/astro-clerk-auth/src/astro-components/react/SignUp.astro
+++ b/packages/astro-clerk-auth/src/astro-components/react/SignUp.astro
@@ -2,12 +2,10 @@
 import type { SignUpProps } from "@clerk/types";
 type Props = SignUpProps
 
-import { signInUrl } from "astro-clerk-auth/v0";
 import { SignUp as SignUpReact } from "astro-clerk-auth/client/react";
 
 const props = {
-  ...Astro.props,
-  signInUrl: Astro.props.signInUrl || signInUrl
+  ...Astro.props
 }
 ---
 


### PR DESCRIPTION
Those values may be incorrect in the CF worker runtime, but also not needed because the correct values are passed from the middleware down to the client and clerk is initialized with the correct values from server.