### PR TITLE
docs: add imports to code samples

### DIFF
--- a/packages/astro-clerk-auth/README.md
+++ b/packages/astro-clerk-auth/README.md
@@ -82,6 +82,8 @@ export const onRequest = clerkMiddleware();
 
 **Supports chaining with `sequence`**
 ```ts
+import { clerkMiddleware } from "astro-clerk-auth/server";
+
 const greeting = defineMiddleware(async (context, next) => {
   console.log("greeting request");
   console.log(context.locals.auth());
@@ -98,6 +100,8 @@ export const onRequest = sequence(
 
 **Advanced use with handler**
 ```ts
+import { clerkMiddleware, createRouteMatcher } from "astro-clerk-auth/server";
+
 const isProtectedPage = createRouteMatcher(['/user(.*)', '/discover(.*)', /^\/organization/])
 
 export const onRequest = clerkMiddleware((auth, context, next) => {


### PR DESCRIPTION
Examples were missing imports. This adds them to avoid a trip to the demo source code.